### PR TITLE
Added regression test for new anthropic interleaved thinking feature

### DIFF
--- a/docs/anthropic_format_output_note.md
+++ b/docs/anthropic_format_output_note.md
@@ -1,0 +1,13 @@
+## Anthropic `format_output` note
+
+The combined change in `d83b831` and `f482ed5` appears directionally correct for Anthropic's documented extended-thinking responses, especially:
+
+- `thinking -> text -> tool_use`
+- `thinking -> tool_use`
+- multiple `tool_use` blocks in one response
+
+The main remaining concern is not a clearly documented live bug, but a potential parser assumption mismatch if Anthropic expands the range of content block orderings in the future.
+
+The important regression to guard against is simpler and already known: after `d83b831`, tool-first responses with multiple `tool_use` blocks could lose the first tool call because later post-processing rebuilt `ToolCalls` from `content[1:]`. `f482ed5` fixes that by returning early from the tool-first branch.
+
+Tests should cover the documented extended-thinking shapes above plus the multi-tool regression.

--- a/src/fdllm/anthropic/caller.py
+++ b/src/fdllm/anthropic/caller.py
@@ -215,6 +215,11 @@ class ClaudeCaller(LLMCaller):
                             **token_count_kwargs,
                         )
                         # Process ALL content items as tool calls
+                        # Anthropic documents tool-first responses such as
+                        # thinking -> tool_use and multiple tool_use blocks.
+                        # If they later expand this branch to allow trailing
+                        # non-tool blocks after a tool-first start, revisit
+                        # this loop and add coverage for that ordering.
                         out.ToolCalls = []
                         for tcout in content:
                             tc = LLMToolCall(

--- a/tests/fdllm/anthropic/anthropic_caller_test.py
+++ b/tests/fdllm/anthropic/anthropic_caller_test.py
@@ -495,6 +495,86 @@ class TestFormatOutput:
         assert result.Message == "Answer"
         assert result.TokensUsedReasoning == 5
 
+    def test_with_thinking_text_then_tool_use(self, caller):
+        """Test documented extended-thinking shape: thinking -> text -> tool_use."""
+        thinking = BetaThinkingBlock(type="thinking", thinking="Need a tool", signature="sig")
+        output = SimpleNamespace(
+            content=[
+                thinking,
+                make_text_block("I'll look that up."),
+                make_tool_block("c1", "search", {"q": "test"}),
+            ],
+            usage=Usage(input_tokens=10, output_tokens=30),
+        )
+
+        with patch.object(
+            caller.Client.beta.messages,
+            "count_tokens",
+            return_value=SimpleNamespace(input_tokens=5),
+        ):
+            result = caller.format_output(output)
+
+        assert result.Message == "I'll look that up."
+        assert result.TokensUsedReasoning == 5
+        assert len(result.ToolCalls) == 1
+        assert result.ToolCalls[0].ID == "c1"
+        assert result.ToolCalls[0].Name == "search"
+        assert result.ToolCalls[0].Args == {"q": "test"}
+
+    def test_with_thinking_then_tool_use(self, caller):
+        """Test documented extended-thinking shape: thinking -> tool_use."""
+        thinking = BetaThinkingBlock(type="thinking", thinking="Need a tool", signature="sig")
+        output = SimpleNamespace(
+            content=[
+                thinking,
+                make_tool_block("c1", "search", {"q": "test"}),
+            ],
+            usage=Usage(input_tokens=10, output_tokens=30),
+        )
+
+        with patch.object(
+            caller.Client.beta.messages,
+            "count_tokens",
+            return_value=SimpleNamespace(input_tokens=5),
+        ):
+            result = caller.format_output(output)
+
+        assert result.Message == ""
+        assert result.TokensUsedReasoning == 5
+        assert len(result.ToolCalls) == 1
+        assert result.ToolCalls[0].ID == "c1"
+        assert result.ToolCalls[0].Name == "search"
+        assert result.ToolCalls[0].Args == {"q": "test"}
+
+    def test_with_thinking_then_multiple_tool_calls(self, caller):
+        """Regression test: thinking -> multiple tool_use blocks keeps all calls."""
+        thinking = BetaThinkingBlock(type="thinking", thinking="Need tools", signature="sig")
+        output = SimpleNamespace(
+            content=[
+                thinking,
+                make_tool_block("c1", "search", {"q": "test"}),
+                make_tool_block("c2", "lookup", {"id": 1}),
+            ],
+            usage=Usage(input_tokens=10, output_tokens=30),
+        )
+
+        with patch.object(
+            caller.Client.beta.messages,
+            "count_tokens",
+            return_value=SimpleNamespace(input_tokens=5),
+        ):
+            result = caller.format_output(output)
+
+        assert result.Message == ""
+        assert result.TokensUsedReasoning == 5
+        assert len(result.ToolCalls) == 2
+        assert result.ToolCalls[0].ID == "c1"
+        assert result.ToolCalls[0].Name == "search"
+        assert result.ToolCalls[0].Args == {"q": "test"}
+        assert result.ToolCalls[1].ID == "c2"
+        assert result.ToolCalls[1].Name == "lookup"
+        assert result.ToolCalls[1].Args == {"id": 1}
+
     def test_response_schema_structured_output(self, caller):
         """Test format_output with response_schema returns JSON string."""
         class Schema(BaseModel):


### PR DESCRIPTION
We were lacking tests for the anthropic interleaved thinking support, added some.
I made the assumption, based on the anthropic docs, that we can encounter thinking -> text ->tool or thinking -> multiple tool calls, but that we won't encounter thinking -> tool -> thinking. If we ever encounter this scenario then we will have an error, given how the feature was built @Mo-H99 