### PR TITLE
move pytest dependencies to dev dependency group

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,9 +11,6 @@ version = "0.30.0"
 requires-python = ">=3.10, <3.13"
 dependencies = [
     "pyyaml",
-    "pytest",
-    "pytest-cov",
-    "pytest-dotenv",
     "pillow",
     "numpy",
     "pydantic==2.*",
@@ -32,6 +29,9 @@ dependencies = [
 [dependency-groups]
 dev = [
     "ipykernel>=6.29.5",
+    "pytest",
+    "pytest-cov",
+    "pytest-dotenv",
     "reportlab>=4.0.0",
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -549,9 +549,6 @@ dependencies = [
     { name = "openai" },
     { name = "pillow" },
     { name = "pydantic" },
-    { name = "pytest" },
-    { name = "pytest-cov" },
-    { name = "pytest-dotenv" },
     { name = "python-dotenv" },
     { name = "pyyaml" },
     { name = "tenacity" },
@@ -561,6 +558,9 @@ dependencies = [
 [package.dev-dependencies]
 dev = [
     { name = "ipykernel" },
+    { name = "pytest" },
+    { name = "pytest-cov" },
+    { name = "pytest-dotenv" },
     { name = "reportlab" },
 ]
 
@@ -576,9 +576,6 @@ requires-dist = [
     { name = "openai", specifier = ">=1.61.0,<2" },
     { name = "pillow" },
     { name = "pydantic", specifier = "==2.*" },
-    { name = "pytest" },
-    { name = "pytest-cov" },
-    { name = "pytest-dotenv" },
     { name = "python-dotenv", specifier = "==1.*" },
     { name = "pyyaml" },
     { name = "tenacity", specifier = ">=9.1.0" },
@@ -588,6 +585,9 @@ requires-dist = [
 [package.metadata.requires-dev]
 dev = [
     { name = "ipykernel", specifier = ">=6.29.5" },
+    { name = "pytest" },
+    { name = "pytest-cov" },
+    { name = "pytest-dotenv" },
     { name = "reportlab", specifier = ">=4.0.0" },
 ]
 


### PR DESCRIPTION
These shouldn't be in the core dependency group otherwise they get pulled in by anyone using our library. Should only be needed by developers working on this project. (Unless anything i'm not aware of?)