### PR TITLE
uv config: add min ver; add "exclude-newer"

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,3 +44,8 @@ markers = [
 addopts = "-m 'not integration'"
 env_files = [".env"]
 env_override_existing_values = true
+
+[tool.uv]
+required-version = ">=0.11.6"
+# Ignore brand new dependency versions, for cybersecurity and robustness
+exclude-newer = "7 days"

--- a/uv.lock
+++ b/uv.lock
@@ -6,6 +6,10 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 
+[options]
+exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
+exclude-newer-span = "P7D"
+
 [[package]]
 name = "aioboto3"
 version = "13.2.0"


### PR DESCRIPTION
add uv config:
- add min required uv version; 
- add "exclude-newer" than 7 days to ignore brand new dependency versions for cybersecurity.

