### PR TITLE
Add integration tests and refactor env loading for tests

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -1,0 +1,38 @@
+name: Integration Tests
+
+on:
+  pull_request:
+    branches: [main]
+    types: [labeled, reopened, synchronize]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+concurrency:
+  group: integration-tests-pr-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  integration:
+    if: >
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      contains(github.event.pull_request.labels.*.name, 'run-integration')
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    environment: integration-tests
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+        with:
+          python-version: "3.12"
+
+      - name: Run integration tests
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+        run: uv run --frozen pytest -m integration tests/fdllm/integration -q

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
 
     - name: Run tests with coverage
-      run: uv run pytest --cov=src/fdllm --cov-report=xml
+      run: uv run --frozen pytest --cov=src/fdllm --cov-report=xml
 
     - name: Upload coverage to Codecov
       if: matrix.os == 'ubuntu-latest'

--- a/README.md
+++ b/README.md
@@ -246,6 +246,36 @@ If you wish to add as a dependency to a project using uv package manager:
 uv add git+https://github.com/AI-for-Education/fabdata-llm.git@main
 ```
 
+### Development with uv
+
+For normal development, run commands against the committed lockfile without allowing uv to update it:
+
+```shell
+uv sync --frozen
+uv run --frozen pytest
+```
+
+Run live integration tests with provider API keys already present in the environment:
+
+```shell
+uv run --frozen pytest -m integration tests/fdllm/integration -q
+```
+
+For local integration testing, keep API keys in an uncommitted `.env` file and let uv load it for the test command:
+
+```shell
+uv run --frozen --env-file .env pytest -m integration tests/fdllm/integration -q
+```
+
+To intentionally refresh dependencies while avoiding packages published in the last 7 days, update the lockfile with uv's `exclude-newer` option:
+
+```shell
+uv lock --exclude-newer "7 days"
+uv sync --frozen
+```
+
+Do not set `exclude-newer = "7 days"` in global uv configuration for day-to-day work. uv snapshots that relative policy into `uv.lock` as a fixed timestamp, so it should only be applied when deliberately refreshing the lockfile.
+
 ### Configuration
 
 The package comes with a base model configuration which can be extended by user-provided custom configurations. You can get the base model configuration dictionary by:

--- a/README.md
+++ b/README.md
@@ -274,8 +274,6 @@ uv lock --exclude-newer "7 days"
 uv sync --frozen
 ```
 
-Do not set `exclude-newer = "7 days"` in global uv configuration for day-to-day work. uv snapshots that relative policy into `uv.lock` as a fixed timestamp, so it should only be applied when deliberately refreshing the lockfile.
-
 ### Configuration
 
 The package comes with a base model configuration which can be extended by user-provided custom configurations. You can get the base model configuration dictionary by:

--- a/tests/fdllm/anthropic/anthropic_caller_test.py
+++ b/tests/fdllm/anthropic/anthropic_caller_test.py
@@ -6,29 +6,21 @@ import pytest
 import json
 from types import SimpleNamespace, GeneratorType
 from typing import List
-from pathlib import Path
 from unittest.mock import Mock, patch
 from PIL import Image
 
 from pydantic import BaseModel
-from dotenv import load_dotenv
 
 from fdllm import ClaudeCaller
 from fdllm.anthropic import ClaudeStreamingCaller
 from fdllm.llmtypes import LLMMessage, LLMToolCall, LLMImage
 from fdllm.tooluse import Tool, ToolParam, ToolItem
-from fdllm.sysutils import register_models
 
 try:
     from anthropic.types.beta import BetaThinkingBlock, BetaToolUseBlock, BetaTextBlock
     from anthropic.types import Usage
 except ImportError:
     pytest.skip("Anthropic SDK not installed", allow_module_level=True)
-
-HERE = Path(__file__).resolve().parent
-TEST_ROOT = HERE.parent
-
-load_dotenv(TEST_ROOT / "test.env", override=True)
 
 DEFAULT_CLAUDE_MODEL = "claude-sonnet-4-5-20250929"
 

--- a/tests/fdllm/bedrock/bedrock_caller_test.py
+++ b/tests/fdllm/bedrock/bedrock_caller_test.py
@@ -4,24 +4,13 @@ Tests cover initialization, message formatting, tools, images, system messages, 
 """
 import pytest
 from types import SimpleNamespace, GeneratorType
-from pathlib import Path
 from unittest.mock import patch, MagicMock
 from PIL import Image
-
-from dotenv import load_dotenv
 
 from fdllm.bedrock import BedrockCaller
 from fdllm.bedrock.caller import tokenize_bedrock_messages, bedrock_async_wrapper
 from fdllm.llmtypes import LLMMessage, LLMToolCall, LLMImage
 from fdllm.tooluse import Tool, ToolParam
-from fdllm.sysutils import register_models
-
-HERE = Path(__file__).resolve().parent
-TEST_ROOT = HERE.parent
-
-load_dotenv(TEST_ROOT / "test.env", override=True)
-
-register_models(TEST_ROOT / "custom_models_test.yaml")
 
 TEST_MODEL = "bedrock-nova-micro"
 TEST_VISION_MODEL = "bedrock-nova-lite"

--- a/tests/fdllm/chat_test.py
+++ b/tests/fdllm/chat_test.py
@@ -1,23 +1,13 @@
 import pytest
 from unittest.mock import patch
 from typing import List
-from pathlib import Path
 
 from pydantic import PrivateAttr
-from dotenv import load_dotenv
 
 from fdllm.chat import ChatController, ChatPlugin
 from fdllm import OpenAICaller, ClaudeCaller, GoogleGenAICaller
 from fdllm.llmtypes import LLMMessage
-from fdllm.sysutils import register_models
 from fdllm.constants import LLM_DEFAULT_MAX_TOKENS
-
-HERE = Path(__file__).resolve().parent
-TEST_ROOT = HERE
-
-load_dotenv(TEST_ROOT / "test.env", override=True)
-
-register_models(TEST_ROOT / "custom_models_test.yaml")
 
 TEST_PLUGIN_SYSMSG = {0: "A", -1: "B", -2: "C"}
 

--- a/tests/fdllm/conftest.py
+++ b/tests/fdllm/conftest.py
@@ -1,0 +1,18 @@
+from pathlib import Path
+
+from dotenv import load_dotenv
+
+from fdllm.sysutils import register_models
+
+TEST_ROOT = Path(__file__).resolve().parent
+
+
+def _running_integration_only(config):
+    marker_expr = (config.getoption("-m") or "").strip()
+    return "integration" in marker_expr and "not integration" not in marker_expr
+
+
+def pytest_configure(config):
+    if not _running_integration_only(config):
+        load_dotenv(TEST_ROOT / "test.env", override=True)
+    register_models(TEST_ROOT / "custom_models_test.yaml")

--- a/tests/fdllm/custom_models_test.yaml
+++ b/tests/fdllm/custom_models_test.yaml
@@ -9,13 +9,13 @@ Google:
       Token_Window: 1048576
       Token_Limit_Completion: 8192
     gemini-test:
-      Api_Model_Name: models/gemini-2.0-flash
+      Api_Model_Name: models/gemini-2.5-flash
       Vision: True
       Document: True
       Token_Window: 1048576
       Token_Limit_Completion: 8192
     gemini-test-no-doc:
-      Api_Model_Name: models/gemini-2.0-flash
+      Api_Model_Name: models/gemini-2.5-flash
       Vision: True
       Document: False
       Token_Window: 1048576
@@ -31,10 +31,10 @@ Anthropic:
   Document: True
   models:
     claude-test:
-      Api_Model_Name: claude-3-5-sonnet-latest
+      Api_Model_Name: claude-haiku-4-5-20251001
       Token_Limit_Completion: 8192
     claude-test-no-doc:
-      Api_Model_Name: claude-3-5-sonnet-latest
+      Api_Model_Name: claude-haiku-4-5-20251001
       Token_Limit_Completion: 8192
       Document: False
 

--- a/tests/fdllm/document_test.py
+++ b/tests/fdllm/document_test.py
@@ -4,20 +4,10 @@ Tests are parametrized to run across OpenAI, Anthropic, and Google callers.
 """
 import pytest
 import base64
-from pathlib import Path
 from PIL import Image
-
-from dotenv import load_dotenv
 
 from fdllm import OpenAICaller, ClaudeCaller, GoogleGenAICaller
 from fdllm.llmtypes import LLMMessage, LLMDocument, LLMImage
-from fdllm.sysutils import register_models
-
-HERE = Path(__file__).resolve().parent
-TEST_ROOT = HERE
-
-load_dotenv(TEST_ROOT / "test.env", override=True)
-register_models(TEST_ROOT / "custom_models_test.yaml")
 
 # Sample PDF bytes (minimal valid PDF structure for testing)
 MINIMAL_PDF = b"%PDF-1.4\n1 0 obj<</Type/Catalog/Pages 2 0 R>>endobj 2 0 obj<</Type/Pages/Kids[3 0 R]/Count 1>>endobj 3 0 obj<</Type/Page/MediaBox[0 0 612 792]/Parent 2 0 R>>endobj\nxref\n0 4\n0000000000 65535 f \n0000000009 00000 n \n0000000052 00000 n \n0000000101 00000 n \ntrailer<</Size 4/Root 1 0 R>>\nstartxref\n178\n%%EOF"

--- a/tests/fdllm/googlegenai/google_caller_test.py
+++ b/tests/fdllm/googlegenai/google_caller_test.py
@@ -4,23 +4,12 @@ Tests cover message formatting, tools, images, system message handling, and outp
 """
 import pytest
 from types import SimpleNamespace, GeneratorType
-from pathlib import Path
 from unittest.mock import Mock, patch, MagicMock
 from PIL import Image
-
-from dotenv import load_dotenv
 
 from fdllm import GoogleGenAICaller
 from fdllm.llmtypes import LLMMessage, LLMToolCall, LLMImage
 from fdllm.tooluse import Tool, ToolParam
-from fdllm.sysutils import register_models
-
-HERE = Path(__file__).resolve().parent
-TEST_ROOT = HERE.parent
-
-load_dotenv(TEST_ROOT / "test.env", override=True)
-
-register_models(TEST_ROOT / "custom_models_test.yaml")
 
 
 # ===== Basic GoogleGenAICaller Tests =====

--- a/tests/fdllm/integration/conftest.py
+++ b/tests/fdllm/integration/conftest.py
@@ -1,0 +1,48 @@
+"""
+Fixtures for integration tests.
+"""
+import os
+from io import BytesIO
+
+import pytest
+
+DUMMY_API_KEYS = {"a", "a.b"}
+
+
+@pytest.fixture
+def require_api_key():
+    def _require_api_key(env_var):
+        api_key = os.getenv(env_var)
+        if not api_key or api_key in DUMMY_API_KEYS:
+            pytest.skip(f"{env_var} is not configured for integration tests")
+
+    return _require_api_key
+
+
+@pytest.fixture(scope="session")
+def sample_pdf_with_title():
+    """
+    Generate a minimal PDF with a clear title and body text.
+    Returns tuple of (pdf_bytes, expected_title).
+    """
+    from reportlab.lib.pagesizes import letter
+    from reportlab.lib.styles import getSampleStyleSheet
+    from reportlab.platypus import SimpleDocTemplate, Paragraph, Spacer
+
+    buffer = BytesIO()
+    doc = SimpleDocTemplate(buffer, pagesize=letter)
+    styles = getSampleStyleSheet()
+
+    title = "Quantum Fluctuations in Banana Cultivation"
+    body = "This document discusses the theoretical implications of subatomic phenomena on tropical fruit farming."
+
+    story = [
+        Paragraph(f"<b>TITLE: {title}</b>", styles["Title"]),
+        Spacer(1, 24),
+        Paragraph(f"BODY: {body}", styles["Normal"]),
+    ]
+
+    doc.build(story)
+    pdf_bytes = buffer.getvalue()
+
+    return pdf_bytes, title

--- a/tests/fdllm/integration/test_document_e2e.py
+++ b/tests/fdllm/integration/test_document_e2e.py
@@ -1,0 +1,82 @@
+"""
+End-to-end integration tests for PDF document support.
+
+These tests make real API calls and require valid API keys.
+Run with: uv run pytest -m integration
+"""
+import pytest
+
+from fdllm import OpenAICaller, ClaudeCaller, GoogleGenAICaller
+from fdllm.llmtypes import LLMMessage, LLMDocument
+
+
+PROVIDER_CONFIGS = [
+    pytest.param(OpenAICaller, "gpt-4.1-mini", "OPENAI_API_KEY", id="openai"),
+    pytest.param(
+        ClaudeCaller,
+        "claude-test",
+        "ANTHROPIC_API_KEY",
+        id="anthropic",
+    ),
+    pytest.param(GoogleGenAICaller, "gemini-test", "GEMINI_API_KEY", id="google"),
+]
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize("caller_cls,model,env_var", PROVIDER_CONFIGS)
+def test_pdf_title_extraction(
+    caller_cls, model, env_var, sample_pdf_with_title, require_api_key
+):
+    """
+    Send a PDF with a known title and ask the model to extract it.
+    Verify the title appears in the response.
+    """
+    require_api_key(env_var)
+
+    pdf_bytes, expected_title = sample_pdf_with_title
+
+    caller = caller_cls(model=model)
+    doc = LLMDocument(Data=pdf_bytes, Filename="test_document.pdf")
+
+    message = LLMMessage(
+        Role="user",
+        Message="What is the title of this document? Reply with just the title.",
+        Documents=[doc],
+    )
+
+    response = caller.call(message, max_tokens=256)
+
+    assert response.Message is not None, "Response message should not be None"
+    assert expected_title in response.Message, (
+        f"Expected title '{expected_title}' not found in response: {response.Message}"
+    )
+
+
+@pytest.mark.integration
+@pytest.mark.anyio
+@pytest.mark.parametrize("caller_cls,model,env_var", PROVIDER_CONFIGS)
+async def test_pdf_title_extraction_async(
+    caller_cls, model, env_var, sample_pdf_with_title, require_api_key
+):
+    """
+    Async version: Send a PDF with a known title and ask the model to extract it.
+    """
+    require_api_key(env_var)
+
+    pdf_bytes, expected_title = sample_pdf_with_title
+
+    caller = caller_cls(model=model)
+    doc = LLMDocument(Data=pdf_bytes, Filename="test_document.pdf")
+
+    message = LLMMessage(
+        Role="user",
+        Message="What is the title of this document? Reply with just the title.",
+        Documents=[doc],
+    )
+
+    response = await caller.acall(message, max_tokens=256)
+
+    assert response.Message is not None, "Response message should not be None"
+    assert expected_title in response.Message, (
+        f"Expected title '{expected_title}' not found in response: {response.Message}"
+    )

--- a/tests/fdllm/llmtypes_test.py
+++ b/tests/fdllm/llmtypes_test.py
@@ -1,16 +1,8 @@
 import pytest
-from pathlib import Path
-
-from dotenv import load_dotenv
 
 import numpy as np
 from PIL import Image
 from fdllm.llmtypes import LLMMessage, LLMImage
-
-HERE = Path(__file__).resolve().parent
-TEST_ROOT = HERE
-
-load_dotenv(TEST_ROOT / "test.env", override=True)
 
 TEST_MESSAGE = LLMMessage(Role="user", Message="Test input")
 TEST_IM_ARR = np.zeros((2048, 4096, 3))

--- a/tests/fdllm/mistral/mistral_caller_test.py
+++ b/tests/fdllm/mistral/mistral_caller_test.py
@@ -5,26 +5,15 @@ Tests cover initialization, message formatting, output parsing, and tokenization
 import pytest
 import json
 from types import SimpleNamespace, GeneratorType
-from pathlib import Path
 from unittest.mock import patch, MagicMock
-
-from dotenv import load_dotenv
 
 from fdllm.mistralai import MistralCaller
 from fdllm.llmtypes import LLMMessage, LLMToolCall
-from fdllm.sysutils import register_models
 
 try:
     from mistralai.models.chat_completion import ChatMessage
 except ImportError:
     pytest.skip("Mistral AI SDK not installed", allow_module_level=True)
-
-HERE = Path(__file__).resolve().parent
-TEST_ROOT = HERE.parent
-
-load_dotenv(TEST_ROOT / "test.env", override=True)
-
-register_models(TEST_ROOT / "custom_models_test.yaml")
 
 TEST_MODEL = "mistral-large-azure"
 

--- a/tests/fdllm/openai/openai_caller_test.py
+++ b/tests/fdllm/openai/openai_caller_test.py
@@ -5,23 +5,14 @@ Tests cover basic functionality, tools, images, special models, and metadata han
 import pytest
 import json
 from types import SimpleNamespace, GeneratorType
-from pathlib import Path
 from unittest.mock import patch
 from PIL import Image
-
-from dotenv import load_dotenv
 
 from fdllm import OpenAICaller
 from fdllm.openai.caller import OpenAICompletionsCaller
 from fdllm.llmtypes import LLMMessage, LLMToolCall, LLMImage
 from fdllm.openai.tokenizer import tokenize_chatgpt_messages
 from fdllm.tooluse import Tool, ToolParam
-from fdllm.sysutils import register_models
-
-HERE = Path(__file__).resolve().parent
-TEST_ROOT = HERE.parent
-
-load_dotenv(TEST_ROOT / "test.env", override=True)
 
 MESSAGE_ROLES = ("user", "system", "assistant", "error")
 TEST_MESSAGE_TEXT = "This is a test"
@@ -38,8 +29,6 @@ TEST_RESULT_OPENAI = SimpleNamespace(
 DEFAULT_OPENAI_MODEL = "gpt-4.1-mini"
 TEST_MODELS = ["gpt-4.1-mini"]
 TEST_VISION_MODELS = ["gpt-4.1"]
-
-register_models(TEST_ROOT / "custom_models_test.yaml")
 
 
 # ===== Basic OpenAICaller Tests =====

--- a/tests/fdllm/tooluse_test.py
+++ b/tests/fdllm/tooluse_test.py
@@ -2,9 +2,7 @@ import pytest
 from unittest.mock import patch
 from itertools import product
 from typing import List
-from pathlib import Path
 
-from dotenv import load_dotenv
 from pydantic import Field
 
 from fdllm import get_caller
@@ -17,11 +15,6 @@ from fdllm.tooluse import (
     ToolInvalidParamError,
     ToolMissingParamError,
 )
-
-HERE = Path(__file__).resolve().parent
-TEST_ROOT = HERE
-
-load_dotenv(TEST_ROOT / "test.env", override=True)
 
 
 class TESTTOOL1(Tool):


### PR DESCRIPTION
This change adds live PDF document integration tests across OpenAI, Anthropic, and Gemini, covering both sync and async caller paths.

  Test environment setup was cleaned up so unit tests no longer load `tests/fdllm/test.env` at module import time. Instead, test model registration and dummy unit-test env
  setup are centralized in `tests/fdllm/conftest.py`. Integration tests now only read environment variables that are already present, which works cleanly for GitHub Actions
  secrets. For local testing, `.env` can be loaded explicitly through uv.

  Local verification:

  ```bash
  uv run --frozen pytest -q
  uv run --frozen --env-file .env pytest -m integration tests/fdllm/integration -q
```

  Dependency workflow was also documented. Normal development should use --frozen so uv.lock is not rewritten during test runs:

  ```bash
  uv sync --frozen
  uv run --frozen pytest
```

  When intentionally refreshing dependencies, use uv’s 7-day package age guard at lock-update time:

  ```bash
  uv lock --exclude-newer "7 days"
  uv sync --frozen
```

There are no integration tests done for anything else apart from document-mode API calls.


**How integration tests are triggered via CI/CD**

Integration tests now run through a separate GitHub Actions workflow.

  They are triggered by adding the `run-integration` label to a PR. The workflow only runs for same-repository PR branches, so fork PR code is not checked out with provider
  secrets. If the label remains on the PR, integration tests rerun when new commits are pushed.

  Provider API keys should be stored in the `integration-tests` GitHub Environment as environment secrets:

  - `OPENAI_API_KEY`
  - `ANTHROPIC_API_KEY`
  - `GEMINI_API_KEY`

  The environment can optionally require reviewer approval before secrets are exposed. The workflow runs:

  `uv run --frozen pytest -m integration tests/fdllm/integration -q`

  The normal unit-test workflow now also uses `uv run --frozen` so CI does not rewrite `uv.lock`.

**What protects API keys from being exposed**

There are two gates:
First, only users with triage permission can add the `integration-tests` label.
Second, we use a GH environment (instead of a repository secret) because it also allows us to set required reviewers for this environment, that way the workflow only runs after it is explicitly approved.

@ogarrod @tjmurray 