### PR TITLE
Add 'thinking_config' to the list of params to check for in gemini ca…

### DIFF
--- a/src/fdllm/google/caller.py
+++ b/src/fdllm/google/caller.py
@@ -181,6 +181,7 @@ class GoogleGenAICaller(LLMCaller):
             "seed",
             "response_mime_type",
             "response_schema",
+            "thinking_config",
         ]:
             config[arg] = kwargs.pop(arg, None)
         if config.get("response_schema"):


### PR DESCRIPTION
Add support for thinking_config parameter for GoogleGenAICaller calls.

GoogleGenAICaller formats the call parameters passed to self._proc_call_args into a config structure which is expected by the API. To do this, it uses a fixed list of possible parameter names. thinking_config was not previously in this list. This PR simply adds 'thinking_config' to the list of parameters to process.